### PR TITLE
scopedConstantQuery

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyConstantMethodQueryTests.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyConstantMethodQueryTests.class.st
@@ -88,6 +88,14 @@ ClyConstantMethodQueryTests >> testFromSystemScope [
 ]
 
 { #category : #tests }
+ClyConstantMethodQueryTests >> testFromWrongClassScope [
+
+	self queryFromScope: ClyClassScope of: self class superclass.
+	
+	self assert: resultItems isEmpty
+]
+
+{ #category : #tests }
 ClyConstantMethodQueryTests >> testIsEmptyFromEmptyMethodScope [
 	"Constant query do not depends on scope. So we redefine this method"
 	<expectedFailure>

--- a/src/Calypso-SystemQueries/ClyConstantMethodQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyConstantMethodQuery.class.st
@@ -56,7 +56,7 @@ ClyConstantMethodQuery >> async [
 { #category : #execution }
 ClyConstantMethodQuery >> buildResult: aQueryResult [
 
-	aQueryResult fillWith: self installedMethods
+	aQueryResult fillWith: self scopedMethods
 ]
 
 { #category : #execution }
@@ -111,6 +111,22 @@ ClyConstantMethodQuery >> methods [
 { #category : #accessing }
 ClyConstantMethodQuery >> methods: anObject [
 	methods := anObject asIdentitySet
+]
+
+{ #category : #execution }
+ClyConstantMethodQuery >> scopedMethods [
+
+	| installedMethods scopedMethods |
+	installedMethods := self installedMethods.
+	scopedMethods := IdentitySet new.
+	
+	scope methodsDo: [ :each | 
+		(installedMethods includes: each) ifTrue: [ 
+			scopedMethods add: each.
+			installedMethods remove: each.
+			installedMethods ifEmpty: [ ^scopedMethods ] ]].
+	
+	^scopedMethods
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Now constant method query takes into account the scope.It fixes #331