### PR TITLE
fixSelectionVisibility/295

### DIFF
--- a/src/Calypso-Browser/ClyQueryViewMorph.class.st
+++ b/src/Calypso-Browser/ClyQueryViewMorph.class.st
@@ -321,16 +321,25 @@ ClyQueryViewMorph >> ensureSelectedItem [
 		selectionIndex := desiredSelection lastSelectedItem globalPosition
 									min: self dataSource numberOfRows ].
 	self selection selectItems: {self dataSource elementAt: selectionIndex}.
-	"following sentence is required to make first item selected in cases
-	where browser is just opened and automatic item visibility 
-	can be wrongly computed"
-	UIManager default defer: [self selection ensureVisibleLastItem]
+	self ensureVisibleSelection
 ]
 
 { #category : #controlling }
 ClyQueryViewMorph >> ensureSelectedItemIfNeeded [
 
-	table allowsDeselection ifFalse: [ self ensureSelectedItem ]
+	table allowsDeselection ifFalse: [ self ensureSelectedItem ].
+	self ensureVisibleSelection
+]
+
+{ #category : #controlling }
+ClyQueryViewMorph >> ensureVisibleSelection [
+
+	self selection isEmpty ifFalse: [ ^self ].
+
+	"following sentence is required to make first item selected in cases
+	where browser is just opened and automatic item visibility 
+	can be wrongly computed"
+	UIManager default defer: [self selection ensureVisibleLastItem]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Fix for #295:
ensureSelection should always ensure selection visibility. #ensureSelectedItemIfNeeded could not force selection but if selection exist it should make it visible