### PR TITLE
335-do-not-display-metaclasses-on-extension-list

### DIFF
--- a/src/Calypso-SystemQueries/ClyPackageExtensionScope.class.st
+++ b/src/Calypso-SystemQueries/ClyPackageExtensionScope.class.st
@@ -11,7 +11,9 @@ Class {
 { #category : #queries }
 ClyPackageExtensionScope >> classesDo: aBlock [ 
 	self packagesDo: [ :package | 
-		package extendedClasses do: aBlock]
+		package extendedClasses 
+			collect: [ :each | each instanceSide ] 
+			thenDo: aBlock]
 ]
 
 { #category : #queries }


### PR DESCRIPTION
do not collect metaclasses to display extension methods.Fixes #335