### PR TITLE
372-Error-when-browsing-extensions-when-we-extend-instance-and-classe-side

### DIFF
--- a/src/Calypso-SystemQueries/ClyClassQuery.class.st
+++ b/src/Calypso-SystemQueries/ClyClassQuery.class.st
@@ -38,7 +38,7 @@ ClyClassQuery class >> resultItemsType [
 { #category : #execution }
 ClyClassQuery >> buildResult: aQueryResult [
 	| filteredClasses |
-	filteredClasses := OrderedCollection new.
+	filteredClasses := Set new.
 	
 	scope classesDo: [ :each | 
 		(self selectsClass: each) ifTrue: [filteredClasses add: each]].


### PR DESCRIPTION
Correct bug when a package extend a class in instance and class side.

The probem is that in the filteredClasses we will sometimes add two time the same class because there is the instance side result and the class side result. With this fix we use a Set to manage this case.

Fixes #372