### PR TITLE
enhancement/divide-packages-radio-button

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToPackagesCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToPackagesCommand.class.st
@@ -14,31 +14,25 @@ ClySwitchToPackagesCommand class >> toolbarOrder [
 
 { #category : #accessing }
 ClySwitchToPackagesCommand >> defaultMenuItemName [
-	^browser isScopedModeEnabled 
-		ifTrue: [ 'Scoped pckg' ]
-		ifFalse: [ 'Packages' ]
+	
+	^ 'All Packages' 
 ]
 
 { #category : #accessing }
 ClySwitchToPackagesCommand >> description [
-	self isAppliedToBrowser ifFalse: [ ^'Click to show packages' ].
-	
-	^browser isScopedModeEnabled 
-		ifTrue: [ 'Click to reset scope' ]
-		ifFalse: [ 'Click to scope by selected packages' ]
+	^ 'Click to show all packages'.
 ]
 
 { #category : #execution }
 ClySwitchToPackagesCommand >> execute [
-	self isAppliedToBrowser ifFalse: [ ^browser switchToPackages].
-	browser isScopedModeEnabled ifTrue: [ ^browser switchToPackages ].
+	^browser switchToPackages
 
-	browser packageSelection actualObjects ifNotEmpty: [ :packages |
-		browser switchToPackageScopeOf: packages]
+"	browser packageSelection actualObjects ifNotEmpty: [ :packages |
+		browser switchToPackageScopeOf: packages]"
 ]
 
 { #category : #testing }
 ClySwitchToPackagesCommand >> isAppliedToBrowser [
 
-	^browser packageView showsItemsFromQuery: ClyAllPackages
+	^ (browser packageView showsItemsFromQuery: ClyAllPackages) and: [ browser isScopedModeEnabled not ]
 ]

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToPackagesCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToPackagesCommand.class.st
@@ -26,9 +26,6 @@ ClySwitchToPackagesCommand >> description [
 { #category : #execution }
 ClySwitchToPackagesCommand >> execute [
 	^browser switchToPackages
-
-"	browser packageSelection actualObjects ifNotEmpty: [ :packages |
-		browser switchToPackageScopeOf: packages]"
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToProjectsCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToProjectsCommand.class.st
@@ -11,6 +11,12 @@ Class {
 	#category : #'Calypso-SystemTools-FullBrowser-Commands-Packages'
 }
 
+{ #category : #testing }
+ClySwitchToProjectsCommand class >> canBeExecutedInContext: aContext [
+
+	^ ClySystemEnvironment currentImage projectManager projectManagers notEmpty 
+]
+
 { #category : #accessing }
 ClySwitchToProjectsCommand >> defaultMenuItemName [
 	^'Projects'

--- a/src/Calypso-SystemTools-FullBrowser/ClySwitchToScopedViewCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClySwitchToScopedViewCommand.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #ClySwitchToScopedViewCommand,
+	#superclass : #ClySwitchPackageViewModeCommand,
+	#category : #'Calypso-SystemTools-FullBrowser-Commands-Packages'
+}
+
+{ #category : #activation }
+ClySwitchToScopedViewCommand class >> toolbarOrder [
+	^1
+]
+
+{ #category : #accessing }
+ClySwitchToScopedViewCommand >> defaultMenuItemName [
+	
+	^ 'Scoped View' 
+]
+
+{ #category : #accessing }
+ClySwitchToScopedViewCommand >> description [
+
+	^ 'Scope to selected packages'.
+]
+
+{ #category : #execution }
+ClySwitchToScopedViewCommand >> execute [
+	
+	^ browser packageSelection actualObjects ifNotEmpty: [ :packages |
+		browser switchToPackageScopeOf: packages]
+]
+
+{ #category : #testing }
+ClySwitchToScopedViewCommand >> isAppliedToBrowser [
+
+	^ (browser packageView showsItemsFromQuery: ClyAllPackages) and: [ browser isScopedModeEnabled ]
+]


### PR DESCRIPTION
Hiding the project button if there is no project manager.
Spliting the packages and scope in two options so it is clear to use. 
Before, nobody knows about this functionality, also It allows us to have better use of the window's real state when there is no project option.