### PR TITLE
To reduce future conflicts with baseline versions

### DIFF
--- a/src/BaselineOfCalypso/BaselineOfCalypso.class.st
+++ b/src/BaselineOfCalypso/BaselineOfCalypso.class.st
@@ -11,14 +11,14 @@ BaselineOfCalypso >> baseline: spec [
 		spec 
 			baseline: 'ClassAnnotation' with: [
 				spec
-					repository: 'github://pharo-ide/ClassAnnotation:v0.4.0/src';
+					repository: 'github://pharo-ide/ClassAnnotation:v0.4.x/src';
 					loads: 'Core' ];
 			project: 'ClassAnnotationTests' copyFrom: 'ClassAnnotation' with: [
 				spec loads: 'Tests'];
 			baseline: 'Commander' with: [
-				spec repository: 'github://pharo-ide/Commander:v0.7.2/src' ];
+				spec repository: 'github://pharo-ide/Commander:v0.7.x/src' ];
 			baseline: 'SystemCommands' with: [
-				spec repository: 'github://pharo-ide/SystemCommands:v0.11.1/src' ].			
+				spec repository: 'github://pharo-ide/SystemCommands:v0.11.x/src' ].			
 
 		spec 
 			package: #'Calypso-NavigationModel';


### PR DESCRIPTION
I want to reduce future conflicts of baseline when we merge dev into master. Idea that dev branch should bring all fixes of dependencies and therefore dev branch uses floating versions. But master branch should use static versions which I will change directly in master branch after this PR. 
So new PRs will not conflict baseline and will not break those rules.

In addition it brings fix for #421.