### PR TITLE
425-Error-when-creating-a-setUp-method-for-a-test

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
@@ -77,7 +77,7 @@ ClyTestSetUpEditorTool >> setUpModelFromContext [
 ClyTestSetUpEditorTool >> setUpParametersFromModel [
 
 	editingMethod := testClass lookupSelector: #setUp.
-	self updateMethodTagsAndPackage
+	super setUpParametersFromModel
 ]
 
 { #category : #controlling }


### PR DESCRIPTION
#425: fix bad override without super call