### PR TITLE
424-Cannot-remove-a-class-that-has-spurious-references-to-it

### DIFF
--- a/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-Core/ClyBrowserMorph.extension.st
@@ -29,10 +29,23 @@ ClyBrowserMorph >> confirmEmptySystemQuery: aQuery [
 { #category : #'*Calypso-SystemTools-Core' }
 ClyBrowserMorph >> confirmUnusedClasses: classes [
 	
-	| refQuery |
-	refQuery := ClyClassReferencesQuery toAny: classes from: self systemScope.
+	| refQuery noUsers answer subclasses users |
+	refQuery := ClyClassReferencesQuery toAny: classes from: self systemScope.	
+	noUsers := self confirmEmptySystemQuery: refQuery.
 	
-	^self confirmEmptySystemQuery: refQuery
+	(classes anySatisfy: [ :each | each hasSubclasses ]) ifTrue: [
+		noUsers := false.
+		answer := UIManager default confirm: 'There are subclasses. Show them?'.
+		subclasses := classes flatCollect: [ :each | each subclasses ].
+		answer ifTrue: [ self spawnQueryBrowserOn: (ClyConstantQuery returning: subclasses) ]].
+		
+	(classes anySatisfy: [ :each | each users notEmpty]) ifTrue: [
+		noUsers := false.
+		answer := UIManager default confirm: 'There are users of trait. Show them?'.
+		users := classes flatCollect: [ :each | each users ].
+		answer ifTrue: [ self spawnQueryBrowserOn: (ClyConstantQuery returning: users) ]].
+	
+	^noUsers
 ]
 
 { #category : #'*Calypso-SystemTools-Core' }


### PR DESCRIPTION
#424: #confirmUnusedClasses should check subclasses and trait users.
It adds same guards like in RBRemoveClassRefactoring which will allow to ignore own refactoring warnings and continue removal even when class has any kind of users