### PR TITLE
437-Possibility-to-not-open-a-MessageBrowser-if-there-is-no-sendersimplementors

### DIFF
--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -53,10 +53,9 @@ ClyBrowserMorph >> spawnQueryBrowserOn: aQuery withState: navigationBlock [
 	
 	targetQuery scope = self systemScope ifTrue: [ 
 		"If query is empty in system (global) scope then it is empty in any other scope.
-		In that case do not need a query browser because it will be always empty and useless"
+		In that case we do not need a query browser because it will be always empty and useless"
 		targetQuery semiAsync hasEmptyResult ifTrue: [ 
-			"For slow queries we will not wait 
-			and open show a browser which will indicate execution progress"
+			"For slow queries we will not wait and open a browser to indicate execution progress"
 			^self inform: 'There are no ', targetQuery description ]  ].
 	
 	self spawnBrowser: ClyQueryBrowser withState: [ :browser | 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -41,7 +41,7 @@ ClyBrowserMorph >> browseSendersOf: aSymbol [
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyBrowserMorph >> spawnQueryBrowserOn: aQuery [
 	
-	^self spawnQueryBrowserOn: aQuery withState: []
+	self spawnQueryBrowserOn: aQuery withState: []
 ]
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
@@ -50,8 +50,11 @@ ClyBrowserMorph >> spawnQueryBrowserOn: aQuery withState: navigationBlock [
 	targetQuery := aQuery.
 	aQuery isBoundToEnvironment ifFalse: [ 
 		targetQuery := aQuery withScope: self defaultNavigationScope].
+	targetQuery scope = self systemScope ifTrue: [ 
+		targetQuery semiAsync hasEmptyResult ifTrue: [ 
+			^self inform: 'There are no ', targetQuery description ]  ].
 	
-	^self spawnBrowser: ClyQueryBrowser withState: [ :browser | 
+	self spawnBrowser: ClyQueryBrowser withState: [ :browser | 
 		browser queryScopes: self allNavigationScopes.
 		browser showResultOf: targetQuery.
 		navigationBlock valueWithPossibleArgs: {browser}]

--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserMorph.extension.st
@@ -50,8 +50,13 @@ ClyBrowserMorph >> spawnQueryBrowserOn: aQuery withState: navigationBlock [
 	targetQuery := aQuery.
 	aQuery isBoundToEnvironment ifFalse: [ 
 		targetQuery := aQuery withScope: self defaultNavigationScope].
+	
 	targetQuery scope = self systemScope ifTrue: [ 
+		"If query is empty in system (global) scope then it is empty in any other scope.
+		In that case do not need a query browser because it will be always empty and useless"
 		targetQuery semiAsync hasEmptyResult ifTrue: [ 
+			"For slow queries we will not wait 
+			and open show a browser which will indicate execution progress"
 			^self inform: 'There are no ', targetQuery description ]  ].
 	
 	self spawnBrowser: ClyQueryBrowser withState: [ :browser | 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyBrowserToolMorph.extension.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyBrowserToolMorph.extension.st
@@ -2,5 +2,5 @@ Extension { #name : #ClyBrowserToolMorph }
 
 { #category : #'*Calypso-SystemTools-QueryBrowser' }
 ClyBrowserToolMorph >> spawnQueryBrowserOn: aQuery [ 
-	^browser spawnQueryBrowserOn: aQuery
+	browser spawnQueryBrowserOn: aQuery
 ]

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
@@ -424,7 +424,7 @@ ClyQueryBrowser >> spawnQueryBrowserOn: aQuery withState: navigationState [
 		ifTrue: [ aQuery ]
 		ifFalse: [ aQuery withScope: activeScope].
 	
-	^super spawnQueryBrowserOn: actualQuery withState: navigationState
+	super spawnQueryBrowserOn: actualQuery withState: navigationState
 ]
 
 { #category : #navigation }


### PR DESCRIPTION
Fixes #437:  spawn query browser request is now checking if given query is empty before open the browser.
This change requires do not return instance of spawned browser because in case of empty query it is not returned anymore. So all returning sentences are removed. They were not used and to prepare spawned browser there is a block parameter in spawn method.