### PR TITLE
444-Class-initialize-button-problem-when-installed-from-a-Trait-

### DIFF
--- a/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScript.class.st
+++ b/src/Calypso-SystemPlugins-ClassScripts-Queries/ClyClassScript.class.st
@@ -107,8 +107,13 @@ ClyClassScript >> implementorMethod: anObject [
 	implementorMethod := anObject
 ]
 
+{ #category : #accessing }
+ClyClassScript >> implementorSelector [
+	^ implementorMethod selector
+]
+
 { #category : #testing }
 ClyClassScript >> isImplementedByClass: aClass [
 	
-	^ aClass instanceSide isKindOf: self implementorClass
+	^ aClass instanceSide respondsTo: self implementorSelector
 ]


### PR DESCRIPTION
#444: check that given class understands script selector instead of is kind logicIt also fixes examples methods defined in traits