### PR TITLE
448 move methods to class doesn't appear in menu but there is a command

### DIFF
--- a/src/Calypso-SystemTools-Core/SycMoveMethodsToClassCommand.extension.st
+++ b/src/Calypso-SystemTools-Core/SycMoveMethodsToClassCommand.extension.st
@@ -7,3 +7,10 @@ SycMoveMethodsToClassCommand class >> methodBrowserDragAndDropActivation [
 	^CmdDragAndDropActivation 
 		for: ClyMethod asCalypsoItemContext toDropIn: ClyClass asCalypsoItemContext
 ]
+
+{ #category : #'*Calypso-SystemTools-Core' }
+SycMoveMethodsToClassCommand class >> methodMenuActivation [
+	<classAnnotation>
+	
+	^CmdContextMenuActivation byRootGroupItemFor: ClyMethod asCalypsoItemContext 
+]


### PR DESCRIPTION
As agreed - here's the fix for the missing annotation. Fixes #448 