### PR TITLE
445 calypso doesnt always correctly show the diamond indicator for an overridden method

### DIFF
--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyInheritanceAnalysisEnvironmentPlugin.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyInheritanceAnalysisEnvironmentPlugin.class.st
@@ -111,8 +111,9 @@ ClyInheritanceAnalysisEnvironmentPlugin >> detachFromSystem [
 ClyInheritanceAnalysisEnvironmentPlugin >> doesClassCache: classCache includesOverridesOf: aClass [
 
 	classCache keysDo: [ :eachClass | 
-		((eachClass includesBehavior: aClass) or: [ aClass includesBehavior: eachClass ])
-			ifTrue: [ ^true ]].
+		((eachClass instanceSide includesBehavior: aClass instanceSide) 
+			or: [ aClass instanceSide includesBehavior: eachClass instanceSide ])
+				ifTrue: [ ^true ]].
 		
 	^false
 ]

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverriddenSuperclassesChanged.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverriddenSuperclassesChanged.class.st
@@ -26,7 +26,7 @@ ClyOverriddenSuperclassesChanged class >> overridingSubclass: aClass [
 { #category : #testing }
 ClyOverriddenSuperclassesChanged >> affectsMethodsDefinedInClass: aClass [
 
-	^overridingSubclass inheritsFrom: aClass
+	^overridingSubclass inheritsFrom: aClass instanceSide
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingSubclassesChanged.class.st
+++ b/src/Calypso-SystemPlugins-InheritanceAnalysis-Queries/ClyOverridingSubclassesChanged.class.st
@@ -28,7 +28,7 @@ ClyOverridingSubclassesChanged class >> overriddenSuperclass: aClass [
 { #category : #testing }
 ClyOverridingSubclassesChanged >> affectsMethodsDefinedInClass: aClass [
 
-	^aClass includesBehavior: overriddenSuperclass
+	^aClass instanceSide includesBehavior: overriddenSuperclass
 ]
 
 { #category : #testing }

--- a/src/Calypso-SystemTools-FullBrowser/ClyFullBrowser.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyFullBrowser.class.st
@@ -138,6 +138,11 @@ ClyFullBrowser class >> settingsGroupOn: aBuilder [
 		description: 'Settings related to the browser'
 ]
 
+{ #category : #icons }
+ClyFullBrowser class >> taskbarIconName [
+	^#smallSystemBrowser
+]
+
 { #category : #'world menu' }
 ClyFullBrowser class >> worldMenuOn: aBuilder [ 
 	<worldMenu> 


### PR DESCRIPTION
- Overrides analysis should use instance side when processes class definition changes
- add missing task bar icon (improved #434 )