### PR TITLE
Fixes #453: variable context should be used for items of variables query

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyVariableContextOfFullBrowser.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyVariableContextOfFullBrowser.class.st
@@ -15,6 +15,13 @@ ClyVariableContextOfFullBrowser class >> selectionStrategy [
 		priority: 1000 "variable context should be with more priority than basic method group context"
 ]
 
+{ #category : #'selection strategy' }
+ClyVariableContextOfFullBrowser class >> selectionStrategy2 [
+	<classAnnotation>
+	
+	^(ClyContextSelectionStrategy for: ClyFullBrowser selectionType: ClyVariable)
+]
+
 { #category : #'selection-variables' }
 ClyVariableContextOfFullBrowser >> isGlobalVariableSelected [
 	^false


### PR DESCRIPTION
When nothing is selected in variables pane the type of query items is analyzed to select appropriate context. And in that case it is ClyVariable subclasses.