### PR TITLE
Fix test for class comments query which fails in Pharo 8

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
@@ -61,7 +61,7 @@ ClyClassCommentsQueryTest >> testFromClassScope [
 ClyClassCommentsQueryTest >> testFromClassWithoutCommentWhenPatternSatisfiesCommentTemplate [
 
 	| noCommentClass substring |
-	noCommentClass := self class superclass.
+	noCommentClass := Object newAnonymousSubclass.
 	self deny: noCommentClass hasComment.
 	substring := noCommentClass comment copyFrom: 4 to: 30.
 	


### PR DESCRIPTION
This test used a test class to check how query works on classes without comment.
But now in Pharo 8 all tests have a comment by default. 
So this PR modifies test to use anonymous subclass of Object as example of class without comment