### PR TITLE
Update 0.16.x: fix test for Pharo 8

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
@@ -61,7 +61,7 @@ ClyClassCommentsQueryTest >> testFromClassScope [
 ClyClassCommentsQueryTest >> testFromClassWithoutCommentWhenPatternSatisfiesCommentTemplate [
 
 	| noCommentClass substring |
-	noCommentClass := self class superclass.
+	noCommentClass := Object newAnonymousSubclass.
 	self deny: noCommentClass hasComment.
 	substring := noCommentClass comment copyFrom: 4 to: 30.
 	


### PR DESCRIPTION
Test cases now always have tests and this test used test class to check how query works on classes without comment.
Now test creates anonymous subclass for this purpose.