### PR TITLE
476-Add-new-API-to-browse-classes-using-query-browser

### DIFF
--- a/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
+++ b/src/Calypso-SystemTools-OldToolCompatibillity/ClyOldMessageBrowserAdapter.class.st
@@ -63,6 +63,11 @@ ClyOldMessageBrowserAdapter class >> browse: methods title: aString autoSelect: 
 ]
 
 { #category : #opening }
+ClyOldMessageBrowserAdapter class >> browseClasses: classes [ 
+	^ClyQueryBrowser browseClasses: classes
+]
+
+{ #category : #opening }
 ClyOldMessageBrowserAdapter class >> browseImplementorsOf: aSymbol [ 
 	^ClyQueryBrowser browseImplementorsOf: aSymbol 
 

--- a/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
+++ b/src/Calypso-SystemTools-QueryBrowser/ClyQueryBrowser.class.st
@@ -47,6 +47,11 @@ Class {
 }
 
 { #category : #opening }
+ClyQueryBrowser class >> browseClasses: classes [
+	^self openOn: (ClyConstantQuery returning: classes)
+]
+
+{ #category : #opening }
 ClyQueryBrowser class >> browseImplementorsOf: aSymbol [
 	^self openOn: (ClyMessageImplementorsQuery of: aSymbol)
 


### PR DESCRIPTION
It fixes #476: #browseClasses: API for query browser
Example:
   Smalltalk tools messageList browseClasses: {Array. Point}