### PR TITLE
New version: API to browse classes using query browser

### DIFF
--- a/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
+++ b/src/Calypso-SystemQueries-Tests/ClyClassCommentsQueryTest.class.st
@@ -61,7 +61,7 @@ ClyClassCommentsQueryTest >> testFromClassScope [
 ClyClassCommentsQueryTest >> testFromClassWithoutCommentWhenPatternSatisfiesCommentTemplate [
 
 	| noCommentClass substring |
-	noCommentClass := self class superclass.
+	noCommentClass := Object newAnonymousSubclass.
 	self deny: noCommentClass hasComment.
 	substring := noCommentClass comment copyFrom: 4 to: 30.
 	


### PR DESCRIPTION
New message is added to support old Nautilus openOnEnvironment use cases.
```Smalltalk
Smalltalk tools messageList browseClasses: {Point. Array}
```